### PR TITLE
Updating webhook IP check to leverage new URL.

### DIFF
--- a/check_webhooks.sh
+++ b/check_webhooks.sh
@@ -6,7 +6,7 @@ if [ -f "webhooks_result.txt" ]; then
   mv webhooks_result.txt webhooks_result.txt.old
 fi
 
-dig +short webhooks.pagerduty.com | sort > webhooks_result.txt
+curl -s https://app.pagerduty.com/webhook_ips | tr -d \[\]\" | tr , '\n' | sort > webhooks_result.txt
 
 if [ -f "webhooks_result.txt.old" ]; then
   DIFF=$(diff -q 'webhooks_result.txt.old' 'webhooks_result.txt' > /dev/null)

--- a/check_webhooks_and_alert.sh
+++ b/check_webhooks_and_alert.sh
@@ -31,7 +31,7 @@ if [ -f "webhooks_result.txt" ]; then
   mv webhooks_result.txt webhooks_result.txt.old
 fi
 
-dig +short webhooks.pagerduty.com | sort > webhooks_result.txt
+curl -s https://app.pagerduty.com/webhook_ips | tr -d \[\]\" | tr , '\n' | sort > webhooks_result.txt
 
 if [ -f "webhooks_result.txt.old" ]; then
   DIFF=$(diff -q 'webhooks_result.txt.old' 'webhooks_result.txt' > /dev/null)


### PR DESCRIPTION
The previous DNS-based approach is now deprecated and only contains a subset of possible webhook origin IPs.

The new endpoint returns a JSON array of IPs. For simplicity and backward-compatibility I just strip out `[`, `]` and `"` then line break on `,` rather than assuming any JSON util is present.